### PR TITLE
Add download attachments tool

### DIFF
--- a/src/fibery_mcp_server/tools/__init__.py
+++ b/src/fibery_mcp_server/tools/__init__.py
@@ -10,10 +10,11 @@ from fibery_mcp_server.tools.current_date import current_date_tool_name, current
 from fibery_mcp_server.tools.create_entity import create_entity_tool_name, create_entity_tool, handle_create_entity
 from fibery_mcp_server.tools.create_entities_batch import create_entities_batch_tool_name, create_entities_batch_tool, handle_create_entities_batch
 from fibery_mcp_server.tools.update_entity import update_entity_tool_name, update_entity_tool, handle_update_entity
+from fibery_mcp_server.tools.download_attachments import download_attachments_tool_name, download_attachments_tool, handle_download_attachments
 
 
 def handle_list_tools():
-    return [current_date_tool(), schema_tool(), database_tool(), query_tool(), create_entity_tool(), create_entities_batch_tool(), update_entity_tool()]
+    return [current_date_tool(), schema_tool(), database_tool(), query_tool(), create_entity_tool(), create_entities_batch_tool(), update_entity_tool(), download_attachments_tool()]
 
 
 async def handle_tool_call(fibery_client: FiberyClient, name: str, arguments: Dict[str, Any]):
@@ -31,6 +32,8 @@ async def handle_tool_call(fibery_client: FiberyClient, name: str, arguments: Di
         return await handle_create_entities_batch(fibery_client, arguments)
     elif name == update_entity_tool_name:
         return await handle_update_entity(fibery_client, arguments)
+    elif name == download_attachments_tool_name:
+        return await handle_download_attachments(fibery_client, arguments)
     else:
         return [mcp.types.TextContent(type="text", text=f"Error: Unknown tool {name}")]
 

--- a/src/fibery_mcp_server/tools/descriptions/download_attachments
+++ b/src/fibery_mcp_server/tools/descriptions/download_attachments
@@ -1,0 +1,19 @@
+Get download links for attachments from a Fibery entity. You can get links for all attachments from an entity or specify which ones by name or ID.
+
+Use this tool when you need to:
+- Get download URLs for all files/attachments from an entity
+- Get download URLs for specific attachments by name or ID
+- List available attachments for an entity with their download links
+
+The tool will:
+1. Query the entity to get all its attachments with their secrets
+2. Filter attachments based on your criteria (if specified)
+3. Return download URLs in the format: https://FIBERY_HOST/api/files/{secret}
+4. Provide attachment metadata (name, ID, download URL)
+
+Examples:
+- Get download links for all attachments from a Cricket/Player entity
+- Get download link for only "image.png" from a specific entity
+- Get download links for attachments with specific IDs
+
+The returned URLs can be used directly with curl or any HTTP client to download the files.

--- a/src/fibery_mcp_server/tools/descriptions/download_attachments
+++ b/src/fibery_mcp_server/tools/descriptions/download_attachments
@@ -1,19 +1,30 @@
-Get download links for attachments from a Fibery entity. You can get links for all attachments from an entity or specify which ones by name or ID.
+Get download links for attachments from a Fibery entity OR for inline files by their secrets. You can get links for all attachments from an entity, specify which ones by name or ID, or get direct download URLs for inline files found in rich text content.
 
 Use this tool when you need to:
 - Get download URLs for all files/attachments from an entity
 - Get download URLs for specific attachments by name or ID
+- Get download URLs for inline files using their secrets (from markdown pattern /api/files/SECRET)
 - List available attachments for an entity with their download links
 
-The tool will:
+The tool supports two modes:
+1. **Attachment mode**: Query attachments from a specific entity (requires entity_type and entity_id)
+2. **Inline file mode**: Get download URLs for inline files using their secrets (requires file_secrets)
+
+For attachment mode, the tool will:
 1. Query the entity to get all its attachments with their secrets
 2. Filter attachments based on your criteria (if specified)
 3. Return download URLs in the format: https://FIBERY_HOST/api/files/{secret}
-4. Provide attachment metadata (name, ID, download URL)
+4. Provide file metadata (name, ID, download URL)
+
+For inline file mode, the tool will:
+1. Make GET requests to https://FIBERY_HOST/api/files/{secret} for each secret
+2. Follow redirects to get the actual download URLs
+3. Return both the Fibery URL and the final download URL
 
 Examples:
 - Get download links for all attachments from a Cricket/Player entity
 - Get download link for only "image.png" from a specific entity
 - Get download links for attachments with specific IDs
+- Get download link for an inline file with secret "72a2505d-f7a5-4fab-8262-c227c85b3dba"
 
 The returned URLs can be used directly with curl or any HTTP client to download the files.

--- a/src/fibery_mcp_server/tools/download_attachments.py
+++ b/src/fibery_mcp_server/tools/download_attachments.py
@@ -38,8 +38,13 @@ def download_attachments_tool() -> mcp.types.Tool:
                     "items": {"type": "string"},
                     "description": "Optional: List of specific attachment IDs to get download links for. If not provided, returns links for all attachments.",
                 },
+                "file_secrets": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional: List of file secrets to get download links for directly (for inline files from markdown pattern /api/files/SECRET). When provided, entity_type and entity_id are ignored.",
+                },
             },
-            "required": ["entity_type", "entity_id"],
+            "required": [],
         },
     )
 
@@ -47,10 +52,23 @@ def download_attachments_tool() -> mcp.types.Tool:
 async def handle_download_attachments(
     fibery_client: FiberyClient, arguments: Dict[str, Any]
 ) -> List[mcp.types.TextContent]:
-    entity_type = arguments["entity_type"]
-    entity_id = arguments["entity_id"]
+    entity_type = arguments.get("entity_type")
+    entity_id = arguments.get("entity_id")
     attachment_names = arguments.get("attachment_names", [])
     attachment_ids = arguments.get("attachment_ids", [])
+    file_secrets = arguments.get("file_secrets", [])
+
+    # If file_secrets are provided, handle inline files
+    if file_secrets:
+        return await _handle_inline_files(fibery_client, file_secrets)
+
+    # Otherwise, require entity_type and entity_id for attachment queries
+    if not entity_type or not entity_id:
+        return [
+            mcp.types.TextContent(
+                type="text", text="Either file_secrets or both entity_type and entity_id must be provided"
+            )
+        ]
 
     # Query the entity to get all its attachments
     query = {
@@ -118,5 +136,85 @@ async def handle_download_attachments(
         result_text += f"ID: {link['id']}\n"
         result_text += f"Download URL: {link['download_url']}\n"
         result_text += f"Curl command: curl -H 'Authorization: Token YOUR_FIBERY_TOKEN' '{link['download_url']}' -o '{link['name']}'\n\n"
+
+    return [mcp.types.TextContent(type="text", text=result_text)]
+
+
+async def _handle_inline_files(fibery_client: FiberyClient, file_secrets: List[str]) -> List[mcp.types.TextContent]:
+    """Handle inline files by making GET requests to get redirect URLs."""
+    import httpx
+
+    download_links = []
+    base_url = f"https://{fibery_client._FiberyClient__fibery_host}/api/files"
+
+    # Create HTTP client with auth header
+    headers = {"Authorization": f"Token {fibery_client._FiberyClient__fibery_api_token}"}
+
+    async with httpx.AsyncClient(follow_redirects=False) as client:
+        for secret in file_secrets:
+            file_url = f"{base_url}/{secret}"
+
+            try:
+                # Make GET request to get redirect
+                response = await client.get(file_url, headers=headers)
+
+                if response.status_code in [301, 302, 303, 307, 308]:
+                    # Extract redirect URL from Location header
+                    redirect_url = response.headers.get("Location")
+                    if redirect_url:
+                        download_links.append(
+                            {
+                                "secret": secret,
+                                "fibery_url": file_url,
+                                "download_url": redirect_url,
+                            }
+                        )
+                    else:
+                        download_links.append(
+                            {
+                                "secret": secret,
+                                "fibery_url": file_url,
+                                "error": "No redirect URL found",
+                            }
+                        )
+                elif response.status_code == 200:
+                    # Direct access, no redirect needed
+                    download_links.append(
+                        {
+                            "secret": secret,
+                            "fibery_url": file_url,
+                            "download_url": file_url,
+                        }
+                    )
+                else:
+                    download_links.append(
+                        {
+                            "secret": secret,
+                            "fibery_url": file_url,
+                            "error": f"HTTP {response.status_code}: {response.text}",
+                        }
+                    )
+            except Exception as e:
+                download_links.append(
+                    {
+                        "secret": secret,
+                        "fibery_url": file_url,
+                        "error": f"Request failed: {str(e)}",
+                    }
+                )
+
+    # Format results
+    result_text = f"Found {len(download_links)} file(s):\n\n"
+    for link in download_links:
+        result_text += f"Secret: {link['secret']}\n"
+        result_text += f"Fibery URL: {link['fibery_url']}\n"
+
+        if "error" in link:
+            result_text += f"Error: {link['error']}\n"
+        else:
+            result_text += f"Download URL: {link['download_url']}\n"
+            result_text += f"Curl command: curl '{link['download_url']}' -o 'file_{link['secret']}'\n"
+
+        result_text += "\n"
 
     return [mcp.types.TextContent(type="text", text=result_text)]

--- a/src/fibery_mcp_server/tools/download_attachments.py
+++ b/src/fibery_mcp_server/tools/download_attachments.py
@@ -1,0 +1,122 @@
+import os
+from typing import Dict, Any, List
+
+import mcp
+
+from fibery_mcp_server.fibery_client import FiberyClient
+
+download_attachments_tool_name = "download_attachments"
+
+
+def download_attachments_tool() -> mcp.types.Tool:
+    with open(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "descriptions", "download_attachments"), "r"
+    ) as file:
+        description = file.read()
+
+    return mcp.types.Tool(
+        name=download_attachments_tool_name,
+        description=description,
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "entity_type": {
+                    "type": "string",
+                    "description": 'The entity type in "Space/Type" format (e.g., "Cricket/Player", "Product Management/Item")',
+                },
+                "entity_id": {
+                    "type": "string",
+                    "description": "The fibery/id of the entity to get attachments from",
+                },
+                "attachment_names": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional: List of specific attachment names to get download links for. If not provided, returns links for all attachments.",
+                },
+                "attachment_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional: List of specific attachment IDs to get download links for. If not provided, returns links for all attachments.",
+                },
+            },
+            "required": ["entity_type", "entity_id"],
+        },
+    )
+
+
+async def handle_download_attachments(
+    fibery_client: FiberyClient, arguments: Dict[str, Any]
+) -> List[mcp.types.TextContent]:
+    entity_type = arguments["entity_type"]
+    entity_id = arguments["entity_id"]
+    attachment_names = arguments.get("attachment_names", [])
+    attachment_ids = arguments.get("attachment_ids", [])
+
+    # Query the entity to get all its attachments
+    query = {
+        "q/from": entity_type,
+        "q/select": [
+            "fibery/id",
+            {"Files/Files": {"q/select": ["fibery/secret", "Files/Name", "fibery/id"], "q/limit": "q/no-limit"}},
+        ],
+        "q/where": ["=", ["fibery/id"], "$entity-id"],
+        "q/limit": 1,
+    }
+
+    params = {"$entity-id": entity_id}
+
+    command_result = await fibery_client.query(query, params)
+
+    if not command_result.success:
+        return [mcp.types.TextContent(type="text", text=f"Error querying entity: {command_result}")]
+
+    if not command_result.result:
+        return [mcp.types.TextContent(type="text", text=f"Entity with ID {entity_id} not found in {entity_type}")]
+
+    entity = command_result.result[0]
+    files = entity.get("Files/Files", [])
+
+    if not files:
+        return [mcp.types.TextContent(type="text", text=f"No attachments found for entity {entity_id}")]
+
+    # Filter attachments if specific names or IDs are requested
+    filtered_files = files
+    if attachment_names or attachment_ids:
+        filtered_files = []
+        for file in files:
+            if attachment_names and file["Files/Name"] in attachment_names:
+                filtered_files.append(file)
+            elif attachment_ids and file["fibery/id"] in attachment_ids:
+                filtered_files.append(file)
+
+    if not filtered_files:
+        filter_info = ""
+        if attachment_names:
+            filter_info += f" with names {attachment_names}"
+        if attachment_ids:
+            filter_info += f" with IDs {attachment_ids}"
+        return [mcp.types.TextContent(type="text", text=f"No attachments found{filter_info}")]
+
+    # Generate download links
+    download_links = []
+    base_url = f"https://{fibery_client._FiberyClient__fibery_host}/api/files"
+
+    for file in filtered_files:
+        download_url = f"{base_url}/{file['fibery/secret']}"
+        download_links.append(
+            {
+                "name": file["Files/Name"],
+                "id": file["fibery/id"],
+                "secret": file["fibery/secret"],
+                "download_url": download_url,
+            }
+        )
+
+    result_text = f"Found {len(download_links)} attachment(s) for entity {entity_id}:\n\n"
+    for link in download_links:
+        result_text += f"Name: {link['name']}\n"
+        result_text += f"ID: {link['id']}\n"
+        result_text += f"Download URL: {link['download_url']}\n"
+        result_text += f"Curl command: curl -H 'Authorization: Token YOUR_FIBERY_TOKEN' '{link['download_url']}' -o '{link['name']}'\n\n"
+
+    return [mcp.types.TextContent(type="text", text=result_text)]

--- a/src/fibery_mcp_server/tools/download_attachments.py
+++ b/src/fibery_mcp_server/tools/download_attachments.py
@@ -57,7 +57,7 @@ async def handle_download_attachments(
         "q/from": entity_type,
         "q/select": [
             "fibery/id",
-            {"Files/Files": {"q/select": ["fibery/secret", "Files/Name", "fibery/id"], "q/limit": "q/no-limit"}},
+            {"Files/Files": {"q/select": ["fibery/secret", "fibery/name", "fibery/id"], "q/limit": "q/no-limit"}},
         ],
         "q/where": ["=", ["fibery/id"], "$entity-id"],
         "q/limit": 1,
@@ -84,7 +84,7 @@ async def handle_download_attachments(
     if attachment_names or attachment_ids:
         filtered_files = []
         for file in files:
-            if attachment_names and file["Files/Name"] in attachment_names:
+            if attachment_names and file["fibery/name"] in attachment_names:
                 filtered_files.append(file)
             elif attachment_ids and file["fibery/id"] in attachment_ids:
                 filtered_files.append(file)
@@ -105,7 +105,7 @@ async def handle_download_attachments(
         download_url = f"{base_url}/{file['fibery/secret']}"
         download_links.append(
             {
-                "name": file["Files/Name"],
+                "name": file["fibery/name"],
                 "id": file["fibery/id"],
                 "secret": file["fibery/secret"],
                 "download_url": download_url,

--- a/src/fibery_mcp_server/tools/query.py
+++ b/src/fibery_mcp_server/tools/query.py
@@ -36,7 +36,7 @@ def query_tool() -> mcp.types.Tool:
                     ),
                 },
                 "q_where": {
-                    "type": "object",
+                    "type": "array",
                     "description": "\n".join(
                         [
                             'Filter conditions in format [operator, [field_path], value] or ["q/and"|"q/or", ...conditions]. Common usages:',
@@ -81,7 +81,8 @@ def get_rich_text_fields(q_select: Dict[str, Any], database: Database) -> Tuple[
         if not isinstance(field_name, str):
             if isinstance(field_name, list):
                 field_name = field_name[0]
-        if database.fields_by_name().get(field_name, None).is_rich_text():
+        field = database.fields_by_name().get(field_name, None)
+        if field and field.is_rich_text():
             rich_text_fields.append({"alias": field_alias, "name": field_name})
             safe_q_select[field_alias] = [field_name, "Collaboration~Documents/secret"]
     return rich_text_fields, safe_q_select


### PR DESCRIPTION
## Summary
- Add new `download_attachments` tool to get download URLs for entity attachments
- Tool queries Fibery entities and returns structured attachment information with download links
- Supports filtering by attachment name or ID for selective downloads
- Returns curl commands for easy file downloading

## Features
- **Get all attachments**: Retrieve download URLs for all files attached to a Fibery entity
- **Selective filtering**: Filter attachments by name or ID using optional parameters
- **Structured output**: Returns name, ID, secret, download URL, and ready-to-use curl commands
- **Error handling**: Proper validation and error messages for invalid entities or missing attachments

## API Usage
```json
{
  "entity_type": "Cricket/Player", 
  "entity_id": "20f9b920-9752-11e9-81b9-4363f716f666",
  "attachment_names": ["image.png"] // optional
}
```

## Test plan
- [ ] Test with entity that has attachments
- [ ] Test filtering by attachment name
- [ ] Test filtering by attachment ID  
- [ ] Test with entity that has no attachments
- [ ] Test with invalid entity ID
- [ ] Verify download URLs work with curl

🤖 Generated with [Claude Code](https://claude.ai/code)